### PR TITLE
Update assembly attributes and version numbers

### DIFF
--- a/BlazamSetup/Properties/AssemblyInfo.cs
+++ b/BlazamSetup/Properties/AssemblyInfo.cs
@@ -8,11 +8,11 @@ using System.Windows;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BlazamSetup")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Installs Blazam from the web")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Blazam-App")]
 [assembly: AssemblyProduct("BlazamSetup")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]


### PR DESCRIPTION
- Updated `AssemblyDescription` to clarify installation.
- Changed `AssemblyCompany` to "Blazam-App".
- Updated `AssemblyCopyright` year from 2024 to 2025.
- Incremented `AssemblyVersion` and `AssemblyFileVersion` from "1.4.0.0" to "1.7.0.0".